### PR TITLE
Reduce delay between winners from 5 to 3 seconds

### DIFF
--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ func main() {
 		// Select the winners
 		for i := 0; i < numWinners; i++ {
 			fmt.Println("Drum roll please...")
-			time.Sleep(5 * time.Second)
+			time.Sleep(3 * time.Second)
 
 			index := r.Intn(len(rows))
 			winner := rows[index]


### PR DESCRIPTION
The delay between each winner being shown feels a little long. I reduced it to 3 seconds.

Let me know if that is ok.